### PR TITLE
Feature/rewrite forked repo imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# Mod 
+# Mod
+
+* * *
 
 Command line tool to upgrade/downgrade Semantic Import Versioning in Go Modules
 
-### Motivation 
+### Motivation
 
-There are two good use cases to do this: 
+There are two good use cases to do this:
 
-1. If you own a library and you want to introduce a breaking change, then you have to go around all your Go files and sub-pacakges and update the import paths to include v2, v3, etc. This tool just does it automatically with one command. 
+1. If you own a library and you want to introduce a breaking change, then you have to go around all your Go files and sub-pacakges and update the import paths to include v2, v3, etc. This tool just does it automatically with one command.
 
-2. If you own a library that is already tagged v2 or above but is incompatible with Semantic Import Versioning, then 
+2. If you own a library that is already tagged v2 or above but is incompatible with Semantic Import Versioning, then
 this tool can solve the problem for you with one command as well. Introduce a go.mod file with the correct import path, and just run `mod upgrade` once or `mod -t=X upgrade` (where x is the latest tag major) to update the import paths of your go files to match whatever tag you're at.
 
 ### Install
@@ -20,10 +22,10 @@ this tool can solve the problem for you with one command as well. Introduce a go
 `mod upgrade` OR `mod downgrade` from any directory that has go.mod file.
 
 
-The tool will update the major version in the go.mod file and it will 
-traverse all the Go Files and upgrades/downgrades any imports as well. 
+The tool will update the major version in the go.mod file and it will
+traverse all the Go Files and upgrades/downgrades any imports as well.
 
-For example, if you have the following package: 
+For example, if you have the following package:
 
 ```
 // go.mod
@@ -47,7 +49,7 @@ import (
 // rest of file...
 ```
 
-You can run `mod upgrade` from the root of that directory and the above two files will be rewritten as such: 
+You can run `mod upgrade` from the root of that directory and the above two files will be rewritten as such:
 
 ```
 module github.com/me/example/v2
@@ -65,9 +67,9 @@ import (
 // rest of file...
 ```
 
-You can of course, downgrade again or upgrade more incrementally. 
+You can of course, downgrade again or upgrade more incrementally.
 
-You can also run this command inside the example folder 
+You can also run this command inside the example folder
 and notice how the import paths and the module name alike get updated.
 
 ## Status

--- a/cmd/mod/main.go
+++ b/cmd/mod/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"os"
 
+	"github.com/marwan-at-work/mod/fork"
+	"github.com/marwan-at-work/mod/major"
 	"github.com/marwan-at-work/mod/migrate"
 
-	"github.com/marwan-at-work/mod/major"
-	"gopkg.in/urfave/cli.v2"
+	cli "gopkg.in/urfave/cli.v2"
 )
 
 func main() {
@@ -53,6 +54,26 @@ func main() {
 					},
 				},
 			},
+			{
+				Name:        "fork",
+				Usage:       "mod fork <command> <args>",
+				Description: "commands for migrating forked libraries",
+				Subcommands: []*cli.Command{
+					{
+						Name:        "rewrite",
+						Usage:       "mod fork rewrite <src-repo-import-path-to-overwrite>",
+						Description: "rewrite import paths in all .go source files to point to a forked repository import path",
+						Action:      withExit(rewriteFork),
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:    "root",
+								Aliases: []string{"r"},
+								Value:   "./",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -69,6 +90,10 @@ func downgrade(c *cli.Context) error {
 
 func migrateDeps(c *cli.Context) error {
 	return migrate.Run(c.String("token"), c.Int("limit"), c.Bool("test"))
+}
+
+func rewriteFork(c *cli.Context) error {
+	return fork.Run(c.String("root"), c.Args().First())
 }
 
 func withExit(f cli.ActionFunc) cli.ActionFunc {

--- a/cmd/mod_test/README.md
+++ b/cmd/mod_test/README.md
@@ -1,0 +1,29 @@
+# mod_test
+
+* * *
+
+`mod_test` is a tool that creates files, directories and go modules for testing commands. useful for
+development.
+
+### *details*
+
+running
+
+    go test [-v] [-name DIR_NAME] [-cleanup]
+
+creates a directory, by default, called `test_module`.
+
+the following is an example of running
+the `fork rewrite` command against the generated go module `test_module`.
+
+if you've installed the `binary`:
+
+    ~$ cd test_module
+    ~$ mod fork rewrite github.com/old/test_module
+
+or using `go run`:
+
+    ~$ cd ../mod
+    ~$ go run main.go fork rewrite -r ../mod_test/test_module/ github.com/old/test_module
+
+note that in this case, on running the `rewrite` command you may see some errors regarding `imports` and `missing packages`, but that is to be expected as these packages don't actually exist for the `packages` library to work correctly. for any real and existing packages, this _should_ be a non-issue.

--- a/cmd/mod_test/main_test.go
+++ b/cmd/mod_test/main_test.go
@@ -1,0 +1,138 @@
+package main_test
+
+import (
+	"flag"
+	"fmt"
+	"html/template"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+var (
+	cleanup    = flag.Bool("cleanup", false, "remove any files/directories created during testing")
+	moduleName = flag.String("name", "test_module", "name of the module created for testing")
+)
+
+var tmpls = []struct {
+	name string
+	pkg  string
+	path string
+}{
+	{
+		"main",
+		"main",
+		"./",
+	},
+	{
+		"pkg_a_1",
+		"pkg_a",
+		"pkg_a/",
+	},
+	{
+		"pkg_a_2",
+		"pkg_a",
+		"pkg_a/",
+	},
+	{
+		"pkg_b_a_1",
+		"pkg_b_a",
+		"pkg_a/pkg_b_a/",
+	},
+}
+
+// mkworkspace returns a teardown function, the tmp workspace root dir and an error if any
+func mkworkspace(dir string) (func(), *string, error) {
+	if err := os.Mkdir(dir, os.ModePerm); err != nil {
+		return nil, nil, err
+	}
+
+	return func() { os.RemoveAll(dir) }, &dir, nil
+}
+
+// writesrc creates .go source files from templates in the directory ./template/
+func writesrc(modroot, oldimport, modname string) error {
+	for _, srctmpl := range tmpls {
+		pkgpath := filepath.Join(modroot, srctmpl.path)
+
+		if _, err := os.Stat(pkgpath); os.IsNotExist(err) {
+			os.MkdirAll(pkgpath, os.ModePerm)
+		}
+
+		tmpl, err := template.ParseFiles(filepath.Join("template/", srctmpl.name+".tmpl"))
+		if err != nil {
+			return err
+		}
+
+		tmplfd, err := os.Create(filepath.Join(modroot, srctmpl.path, srctmpl.name+".go"))
+		if err != nil {
+			return err
+		}
+		defer tmplfd.Close()
+
+		var args = map[string]string{
+			"PackageName": srctmpl.pkg,
+			"ImportPath":  oldimport,
+			"ModuleName":  modname,
+		}
+
+		if err := tmpl.Execute(tmplfd, args); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// gomodinit will initialise the directory root as a go module
+func gomodinit(modname, root string) error {
+	c := exec.Command("go", "mod", "init", modname)
+
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Dir = root
+
+	err := c.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestForkRewrite(t *testing.T) {
+	modImportPathNew := "github.com/new/" + *moduleName
+	modImportPathOld := "github.com/old/" + *moduleName
+
+	fmt.Println("old module:", modImportPathOld)
+	fmt.Println("new module:", modImportPathNew)
+
+	teardown, dir, err := mkworkspace("test_module")
+	if err != nil {
+		if teardown != nil {
+			teardown()
+		}
+		t.Fatal(err)
+	}
+
+	var root string
+
+	if dir == nil {
+		t.Fatal("the test module root directory is nil")
+	}
+
+	root = *dir
+
+	if *cleanup {
+		defer teardown()
+	}
+
+	if err := writesrc(root, modImportPathOld, *moduleName); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := gomodinit(modImportPathNew, root); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/mod_test/template/main.tmpl
+++ b/cmd/mod_test/template/main.tmpl
@@ -1,0 +1,15 @@
+package {{ .PackageName }}
+
+import "fmt"
+
+func main() {
+    fmt.Println("main")
+}
+
+func F1() string {
+    return "function1"
+}
+
+func F2() string {
+    return "function2"
+}

--- a/cmd/mod_test/template/pkg_a_1.tmpl
+++ b/cmd/mod_test/template/pkg_a_1.tmpl
@@ -1,0 +1,7 @@
+package {{ .PackageName }}
+
+import "{{ .ImportPath }}"
+
+func ExportedFunction1() string {
+    return {{ .ModuleName }}.F1()
+}

--- a/cmd/mod_test/template/pkg_a_2.tmpl
+++ b/cmd/mod_test/template/pkg_a_2.tmpl
@@ -1,0 +1,7 @@
+package {{ .PackageName }}
+
+import "{{ .ImportPath }}"
+
+func ExportedFunction2() string {
+    return {{ .ModuleName }}.F1()
+}

--- a/cmd/mod_test/template/pkg_b_a_1.tmpl
+++ b/cmd/mod_test/template/pkg_b_a_1.tmpl
@@ -1,0 +1,7 @@
+package {{ .PackageName }}
+
+import "{{ .ImportPath }}"
+
+func ExportedFunction1() string {
+    return {{ .ModuleName }}.F2()
+}

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -1,0 +1,28 @@
+package fork
+
+import (
+	"github.com/marwan-at-work/mod"
+	"github.com/pkg/errors"
+)
+
+// Run will overwrite oldImportPath in all src files with the module name found in dir
+func Run(dir, oldImportPath string) error {
+	mf, err := mod.GetModFile(dir)
+	if err != nil {
+		return errors.Wrap(err, "could not get go.mod file")
+	}
+
+	pkgs, err := mod.LoadPackagesIn(dir, true)
+	if err != nil {
+		return errors.Wrap(err, "could not load package syntax")
+	}
+
+	for p := range pkgs {
+		err = mod.UpdateImportPath(p, oldImportPath, mf.Module.Mod.Path)
+		if err != nil {
+			return errors.Wrap(err, "could not update import path")
+		}
+	}
+
+	return nil
+}

--- a/mod.go
+++ b/mod.go
@@ -1,11 +1,16 @@
 package mod
 
 import (
+	"go/format"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/marwan-at-work/vgop/modfile"
 	"github.com/pkg/errors"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
 )
 
 // GetModFile returns an AST of the given directory's go.mod file
@@ -15,9 +20,75 @@ func GetModFile(dir string) (*modfile.File, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not open go.mod file")
 	}
+
 	f, err := modfile.Parse(filepath.Join(dir, "go.mod"), bts, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse go.mod file")
 	}
+
 	return f, nil
+}
+
+// LoadPackagesIn returns a generator that yields package structs, or an error
+// if there was a problem loading the package in the given directory
+func LoadPackagesIn(dir string, tests bool) (<-chan *packages.Package, error) {
+	c := &packages.Config{
+		Mode:  packages.LoadSyntax,
+		Tests: tests,
+		Dir:   dir,
+	}
+
+	pkgs, err := packages.Load(c, "./...")
+	if err != nil {
+		return nil, errors.Wrap(err, dir)
+	}
+
+	gen := make(chan *packages.Package)
+
+	go func() {
+		for _, p := range pkgs {
+			gen <- p
+		}
+
+		close(gen)
+	}()
+
+	return gen, nil
+}
+
+// UpdateImportPath takes a package p, iterates its imports and if import 'old'
+// is found, replace it with import 'new'
+func UpdateImportPath(p *packages.Package, old, new string) error {
+	for _, syn := range p.Syntax {
+		var rewritten bool
+
+		for _, i := range syn.Imports {
+			imp := strings.Replace(i.Path.Value, `"`, ``, 2)
+			if strings.HasPrefix(imp, old) {
+				newImp := strings.Replace(imp, old, new, 1)
+				rewrote := astutil.RewriteImport(p.Fset, syn, imp, newImp)
+				if rewrote {
+					rewritten = true
+				}
+			}
+		}
+
+		if !rewritten {
+			continue
+		}
+
+		goFileName := p.Fset.File(syn.Pos()).Name()
+
+		f, err := os.Create(goFileName)
+		if err != nil {
+			return errors.Wrapf(err, "could not create go file %v", goFileName)
+		}
+		err = format.Node(f, p.Fset, syn)
+		f.Close()
+		if err != nil {
+			return errors.Wrapf(err, "could not rewrite go file %v", goFileName)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
added a command that also can take sub-commands. please let me know if you want me to change it to simply, a single command. i just think it's cool that the command `fork` could possibly be augmented by a sub-command, in this case the sub-command `rewrite`.

also.. the package, `mod_test` is not so much a testing package but is more a tool. it actually makes more sense to change it to use `go generate` but i have to experiment with it more.

look forward to your review (and any questions ..).

thanks.