### PR TITLE
Fix import path prefix collisions

### DIFF
--- a/major/major.go
+++ b/major/major.go
@@ -2,6 +2,7 @@ package major
 
 import (
 	"flag"
+	"fmt"
 	"go/format"
 	"io/ioutil"
 	"log"
@@ -131,7 +132,7 @@ func updateImportPath(p *packages.Package, old, new string) error {
 		var rewritten bool
 		for _, i := range syn.Imports {
 			imp := strings.Replace(i.Path.Value, `"`, ``, 2)
-			if strings.HasPrefix(imp, old) {
+			if strings.HasPrefix(imp, fmt.Sprintf("%s/", old)) || imp == old {
 				newImp := strings.Replace(imp, old, new, 1)
 				rewrote := astutil.RewriteImport(p.Fset, syn, imp, newImp)
 				if rewrote {


### PR DESCRIPTION
If two import paths have the same prefix, versioned imports are not
generated correctly.

For example, consider `k8s.io/api` and `k8s.io/apimachinery`.

Running `mod upgrade -tag=12 -mod-name=k8s.io/api`, will also modify
apimachinery import paths to something like `"k8s.io/api/v12machinery/pkg/runtime"`.

To avoid this, explicitly check if the import path to modify is:
- the old import path itself
- has the prefix `"<old-import-path>/"`

cc @marwan-at-work 
fyi @sttts 