### PR TITLE
Support mod-name in the downgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ All you have to do is
 mod upgrade --mod-name=github.com/x/y
 ```
 
+#### Downgrading a dependency
+
+Say you are using a dependency like `github.com/x/y/v3` and you want to use the previous major version. You don't want to change your own import paths, but you want to change the import paths of a dependency you're using from `v3` to `v2`.
+
+All you have to do is
+
+```
+mod downgrade --mod-name=github.com/x/y
+```
+
 ## Status
 
 Works as intended. Feel free to report any issues.

--- a/cmd/mod/main.go
+++ b/cmd/mod/main.go
@@ -41,7 +41,13 @@ func main() {
 				Usage:       "mod downgrade",
 				Description: "downgrade go.mod and imports one major version",
 				Action:      withExit(downgrade),
-				Flags:       []cli.Flag{buildFlags},
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "mod-name",
+						Value: "",
+					},
+					buildFlags,
+				},
 			},
 			{
 				Name:        "migrate-deps",


### PR DESCRIPTION
### What

Honor the `mod-name` flag for the `downgrade` command:

Otherwise:

```bash
$ mod downgrade --mod-name=github.com/elastic/beats/v8
Incorrect Usage: flag provided but not defined: -mod-name

NAME:
   mod downgrade - mod downgrade

USAGE:
   mod downgrade [command options] [arguments...]

DESCRIPTION:
   downgrade go.mod and imports one major version

OPTIONS:
   --buildflags value  build flags to pass to the go compiler. Most commonly use for build flags ie. 'mod upgrade -buildflags=-tags=dev'
   --help, -h          show help (default: false)
```
