### PR TITLE
feat: ignore go build constraints

### DIFF
--- a/cmd/mod/main.go
+++ b/cmd/mod/main.go
@@ -9,14 +9,9 @@ import (
 )
 
 func main() {
-	buildFlags := &cli.StringSliceFlag{
-		Name:  "buildflags",
-		Usage: "build flags to pass to the go compiler. Most commonly use for build flags ie. 'mod upgrade -buildflags=-tags=dev'",
-	}
 	app := &cli.App{
 		Name:  "mod",
 		Usage: "upgrade/downgrade semantic import versioning",
-		Flags: []cli.Flag{buildFlags},
 		Commands: []*cli.Command{
 			{
 				Name:        "upgrade",
@@ -33,7 +28,6 @@ func main() {
 						Name:  "mod-name",
 						Value: "",
 					},
-					buildFlags,
 				},
 			},
 			{
@@ -46,7 +40,6 @@ func main() {
 						Name:  "mod-name",
 						Value: "",
 					},
-					buildFlags,
 				},
 			},
 			{
@@ -76,11 +69,11 @@ func main() {
 }
 
 func upgrade(c *cli.Context) error {
-	return major.Run(".", "upgrade", c.String("mod-name"), c.Int("tag"), c.StringSlice("buildflags"))
+	return major.Run(".", "upgrade", c.String("mod-name"), c.Int("tag"))
 }
 
 func downgrade(c *cli.Context) error {
-	return major.Run(".", "downgrade", c.String("mod-name"), 0, c.StringSlice("buildflags"))
+	return major.Run(".", "downgrade", c.String("mod-name"), 0)
 }
 
 func migrateDeps(c *cli.Context) error {

--- a/example/subpkg/subpkg.go
+++ b/example/subpkg/subpkg.go
@@ -1,3 +1,5 @@
+//go:build something
+
 package subpkg
 
 import (

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -103,7 +103,7 @@ func migrate(path string, gc *github.Client, test bool) error {
 	}
 	t := getTag(dir)
 	fmt.Printf("upgrading %v to v%v\n", path, t)
-	if err := major.Run(dir, "upgrade", "", t, nil); err != nil {
+	if err := major.Run(dir, "upgrade", "", t); err != nil {
 		return errors.Wrap(err, "err upgrading import paths")
 	}
 


### PR DESCRIPTION
Hi,
first of all: thanks for this great tool! (I'm using it as part of https://github.com/renovatebot/renovate.)

I noticed that `mod` does not ignore [build constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints) when upgrading/downgrading Semantic Import Versioning.

This PR will change `mod`, so it will ignore go build constraints and upgrade/downgrade Semantic Import Versioning in all `.go` files. The flag `buildflags` has been removed, as it makes no sense anymore.

There does not seem to be a way to get the [golang.org/x/tools/go/packages](https://pkg.go.dev/golang.org/x/tools/go/packages) to ignore build constraints, so I now only use it to get information about all packages and their `GoFiles` plus the [`IgnoredFiles`](https://pkg.go.dev/golang.org/x/tools/go/packages#Package.IgnoredFiles) (source files that are not part of the package using the current build configuration but that might be part of the package using other build configurations).

These files are then parsed using [go/parser](https://pkg.go.dev/go/parser). Apart from this, the update logic has not changed.

Cheers
Pascal

PS: I also replaced the deprecated call to `ioutil.WriteFile(…)` with `os.WriteFile(…)`.