### PR TITLE
feat: add a replace command that can be used to handle module relocation and rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Command line tool to upgrade/downgrade Semantic Import Versioning in Go Modules
 
-### Motivation 
+## Motivation 
 
 There are two good use cases to do this: 
 
@@ -11,11 +11,13 @@ There are two good use cases to do this:
 2. If you own a library that is already tagged v2 or above but is incompatible with Semantic Import Versioning, then 
 this tool can solve the problem for you with one command as well. Introduce a go.mod file with the correct import path, and just run `mod upgrade` once or `mod -t=X upgrade` (where x is the latest tag major) to update the import paths of your go files to match whatever tag you're at.
 
-### Install
+## Install
 
 `go install github.com/marwan-at-work/mod/cmd/mod@latest`
 
-### Usage
+## Usage
+
+### upgrade/downgrade
 
 `mod upgrade` OR `mod downgrade` from any directory that has go.mod file.
 
@@ -88,6 +90,19 @@ All you have to do is
 
 ```
 mod downgrade --mod-name=github.com/x/y
+```
+
+### migrate
+
+### replace
+
+If the repos location changed (renamed, moving to vanity urls, etc.) you have to update all application depending on 
+that repo. Meaning you have to search and replace all occurrences of the old location by a new one.
+
+This is what this `replace` command does for you.
+
+```
+mod replace --mod-old=github.com/x/y --mod-new=something.com/x/y
 ```
 
 ## Status

--- a/cmd/mod/main.go
+++ b/cmd/mod/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/marwan-at-work/mod/replace"
 	"github.com/urfave/cli/v2"
 
 	"github.com/marwan-at-work/mod/major"
@@ -65,6 +66,20 @@ func main() {
 					},
 				},
 			},
+			{
+				Name:        "replace",
+				Usage:       "mod replace --mod-old=<ol-module-name> --mod-new=<new-module-name>",
+				Description: "migrate your module that may have changed locations",
+				Action:      withExit(migrateDeps),
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name: "mod-old",
+					},
+					&cli.StringFlag{
+						Name: "mod-new",
+					},
+				},
+			},
 		},
 	}
 
@@ -81,6 +96,10 @@ func downgrade(c *cli.Context) error {
 
 func migrateDeps(c *cli.Context) error {
 	return migrate.Run(c.String("token"), c.Int("limit"), c.Bool("test"))
+}
+
+func replaceDeps(c *cli.Context) error {
+	return replace.Run(".", c.String("mod-old"), c.String("mod-new"))
 }
 
 func withExit(f cli.ActionFunc) cli.ActionFunc {

--- a/cmd/mod/main.go
+++ b/cmd/mod/main.go
@@ -70,13 +70,15 @@ func main() {
 				Name:        "replace",
 				Usage:       "mod replace --mod-old=<ol-module-name> --mod-new=<new-module-name>",
 				Description: "migrate your module that may have changed locations",
-				Action:      withExit(migrateDeps),
+				Action:      withExit(replaceDeps),
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name: "mod-old",
+						Name:     "mod-old",
+						Required: true,
 					},
 					&cli.StringFlag{
-						Name: "mod-new",
+						Name:     "mod-new",
+						Required: true,
 					},
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.18
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/google/go-github/v52 v52.0.0
+	github.com/otiai10/copy v1.14.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.4
 	github.com/urfave/cli/v2 v2.25.1
 	golang.org/x/mod v0.13.0
 	golang.org/x/oauth2 v0.7.0
@@ -17,13 +19,17 @@ require (
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/cloudflare/circl v1.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
 	golang.org/x/net v0.15.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/cloudflare/circl v1.3.2 h1:VWp8dY3yH69fdM7lM6A1+NhhVoDu9vqK0jOgmkQHFW
 github.com/cloudflare/circl v1.3.2/go.mod h1:+CauBF6R70Jqcyl8N2hC8pAXYbWkGIezuSbuGLtRhnw=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
@@ -22,10 +24,17 @@ github.com/google/go-github/v52 v52.0.0 h1:uyGWOY+jMQ8GVGSX8dkSwCzlehU3WfdxQ7Gwe
 github.com/google/go-github/v52 v52.0.0/go.mod h1:WJV6VEEUPuMo5pXqqa2ZCZEdbQqua4zAk2MZTIo+m+4=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
+github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
+github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/urfave/cli/v2 v2.25.1 h1:zw8dSP7ghX0Gmm8vugrs6q9Ku0wzweqPyshy+syu9Gw=
 github.com/urfave/cli/v2 v2.25.1/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
@@ -57,6 +66,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -96,3 +106,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/replace/replace.go
+++ b/replace/replace.go
@@ -1,0 +1,135 @@
+package replace
+
+import (
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/marwan-at-work/mod"
+	"github.com/pkg/errors"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
+)
+
+func Run(dir, oldModName string, newModName string) error {
+	var modFile *modfile.File
+	modFile, err := mod.GetModFile(dir)
+	if err != nil {
+		return errors.Wrap(err, "could not get go.mod file")
+	}
+
+	// loading the packages
+	c := &packages.Config{Mode: packages.NeedName | packages.NeedFiles, Tests: true, Dir: dir}
+	pkgs, err := packages.Load(c, "./...")
+	if err != nil {
+		return errors.Wrap(err, "could not load package")
+	}
+
+	// Starting the processing
+	ids := map[string]struct{}{}
+	files := map[string]struct{}{}
+	for _, p := range pkgs {
+		if _, ok := ids[p.ID]; ok {
+			continue
+		}
+		ids[p.ID] = struct{}{}
+		err = updateImportPath(p, oldModName, newModName, files)
+		if err != nil {
+			return err
+		}
+	}
+
+	// check if this new entry is already in the mode file
+	var alreadyExists bool
+	for _, req := range modFile.Require {
+		if req.Mod.Path == newModName {
+			alreadyExists = true
+			break
+		}
+	}
+
+	// drop the entry from gomod
+	if alreadyExists {
+		err = modFile.DropRequire(oldModName)
+		if err != nil {
+			return fmt.Errorf("error dropping %q: %w", oldModName, err)
+		}
+	} else {
+		for _, req := range modFile.Require {
+			if req.Mod.Path == oldModName {
+				req.Mod.Path = newModName
+				req.Mod.Version = "latest"
+				req.Syntax.Token[1] = newModName
+				break
+			}
+		}
+		modFile.SetRequire(modFile.Require)
+	}
+
+	// Tidy and finish the run
+	bts, err := modFile.Format()
+	if err != nil {
+		return errors.Wrap(err, "could not format go.mod file with new import path")
+	}
+	err = os.WriteFile(filepath.Join(dir, "go.mod"), bts, 0660)
+	if err != nil {
+		return errors.Wrap(err, "could not rewrite go.mod file")
+	}
+	fmt.Println("running go mod tidy...")
+	cmd := exec.Command("go", "mod", "tidy")
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd.Run()
+
+	return nil
+}
+
+func updateImportPath(p *packages.Package, old, new string, files map[string]struct{}) error {
+
+	goFileNames := append(p.GoFiles, p.IgnoredFiles...)
+	for _, goFileName := range goFileNames {
+
+		if _, ok := files[goFileName]; ok {
+			continue
+		}
+		files[goFileName] = struct{}{}
+
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, goFileName, nil, parser.ParseComments)
+		if err != nil {
+			return errors.Wrapf(err, "could not parse go file %v", goFileName)
+		}
+
+		var rewritten bool
+		for _, i := range parsed.Imports {
+			imp := strings.Replace(i.Path.Value, `"`, ``, 2)
+			if strings.HasPrefix(imp, fmt.Sprintf("%s", old)) || imp == old {
+				newImp := strings.Replace(imp, old, new, 1)
+				rewrote := astutil.RewriteImport(fset, parsed, imp, newImp)
+				if rewrote {
+					rewritten = true
+				}
+			}
+		}
+		if !rewritten {
+			continue
+		}
+
+		f, err := os.Create(goFileName)
+		if err != nil {
+			return errors.Wrapf(err, "could not create go file %v", goFileName)
+		}
+		err = format.Node(f, fset, parsed)
+		f.Close()
+		if err != nil {
+			return errors.Wrapf(err, "could not rewrite go file %v", goFileName)
+		}
+	}
+
+	return nil
+}

--- a/replace/replace.go
+++ b/replace/replace.go
@@ -18,6 +18,7 @@ import (
 )
 
 func Run(dir, oldModName string, newModName string) error {
+	fmt.Printf("replace %s by %s", oldModName, newModName)
 	var modFile *modfile.File
 	modFile, err := mod.GetModFile(dir)
 	if err != nil {
@@ -58,7 +59,7 @@ func Run(dir, oldModName string, newModName string) error {
 	if alreadyExists {
 		err = modFile.DropRequire(oldModName)
 		if err != nil {
-			return fmt.Errorf("error dropping %q: %w", oldModName, err)
+			return fmt.Errorf("error dropping %q: %w\n", oldModName, err)
 		}
 	} else {
 		for _, req := range modFile.Require {

--- a/replace/replace_test.go
+++ b/replace/replace_test.go
@@ -1,0 +1,61 @@
+package replace
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	cp "github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	type args struct {
+		dir        string
+		oldModName string
+		newModName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "example1",
+			args: args{
+				dir:        "testdata/example1",
+				oldModName: "github.com/go-playground/webhooks/v6",
+				newModName: "github.com/xnok/webhooks/v6",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				err := cp.Copy(tt.args.dir, dir)
+				require.NoError(t, err)
+
+				if err := Run(dir, tt.args.oldModName, tt.args.newModName); (err != nil) != tt.wantErr {
+					assert.NoError(t, err)
+					fileCheck(t, path.Join(dir, "go.mod"), tt.args.newModName, tt.args.oldModName)
+				}
+			},
+		)
+	}
+}
+
+func fileCheck(t *testing.T, file, new, old string) {
+	t.Helper()
+	// read the whole file at once
+	b, err := os.ReadFile(file)
+	if err != nil {
+		panic(err)
+	}
+	s := string(b)
+	// //check whether s contains substring text
+	assert.Contains(t, s, new)
+	assert.NotContains(t, s, old)
+}

--- a/replace/replace_test.go
+++ b/replace/replace_test.go
@@ -60,7 +60,7 @@ func fileCheck(t *testing.T, file, new, old string) {
 	// read the whole file at once
 	b, err := os.ReadFile(file)
 	if err != nil {
-		panic(err)
+		require.NoError(t, err)
 	}
 	s := string(b)
 	// //check whether s contains substring text

--- a/replace/replace_test.go
+++ b/replace/replace_test.go
@@ -20,6 +20,8 @@ func TestRun(t *testing.T) {
 		name    string
 		args    args
 		wantErr bool
+		// list of file we want to validate for the replacement
+		wantCheckFile []string
 	}{
 		{
 			name: "example1",
@@ -29,6 +31,10 @@ func TestRun(t *testing.T) {
 				newModName: "github.com/xnok/webhooks/v6",
 			},
 			wantErr: false,
+			wantCheckFile: []string{
+				"go.mod",
+				"example.go",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -40,7 +46,9 @@ func TestRun(t *testing.T) {
 
 				if err := Run(dir, tt.args.oldModName, tt.args.newModName); (err != nil) != tt.wantErr {
 					assert.NoError(t, err)
-					fileCheck(t, path.Join(dir, "go.mod"), tt.args.newModName, tt.args.oldModName)
+					for i := range tt.wantCheckFile {
+						fileCheck(t, path.Join(dir, tt.wantCheckFile[i]), tt.args.newModName, tt.args.oldModName)
+					}
 				}
 			},
 		)

--- a/replace/testdata/example1/example.go
+++ b/replace/testdata/example1/example.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/go-playground/webhooks/v6/gitlab"
+
+func main() {
+	gitlab.New(gitlab.Options.Secret("12345"))
+}

--- a/replace/testdata/example1/go.mod
+++ b/replace/testdata/example1/go.mod
@@ -1,0 +1,15 @@
+module github.com/marwan-at-work/mod/example1
+
+go 1.21.4
+
+require github.com/go-playground/webhooks/v6 v6.3.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/gogits/go-gogs-client v0.0.0-20200905025246-8bb8a50cb355 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	github.com/stretchr/testify v1.6.1 // indirect
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION
I discovered your utility via Renovate, which uses it to handle the major upgrade workflow. The module is conveniently called mod, so it could be extended to auto-resolve all the mod-related issues.

Renovate recently introduced the "replacement" feature that can be used to update the dependencies for which the package name has changed. Unfortunately, the gomod manager is not supported, so I am planning to do the work and get it implemented.

There are a few cases where this happens in go
* Repository changes owners or is given to a different organisation 
* Migration to a different repository hosting solution Github <-> Gitlab <-> Bitbucket <-> etc
* Introducing registry or vanity URLs.

My renovate branch for this feature: https://github.com/xNok/renovate/tree/replacement-for-gomod