### PR TITLE
major: do nothing if path already exists

### DIFF
--- a/major/major.go
+++ b/major/major.go
@@ -70,10 +70,7 @@ func Run(dir, op, modName string, tag int) error {
 			}
 		}
 		if majorExists {
-			err = modFile.DropRequire(modName)
-			if err != nil {
-				return fmt.Errorf("error dropping %q: %w", modName, err)
-			}
+			return nil
 		} else {
 			for _, req := range modFile.Require {
 				if req.Mod.Path == modName {


### PR DESCRIPTION
I'm not sure if there's anything to be gained from dropping the require and re-running "go mod tidy". 

Fixes #28