### PR TITLE
Support 'tool' directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/marwan-at-work/mod
 
-go 1.18
+go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/google/go-github/v52 v52.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.25.1
-	golang.org/x/mod v0.13.0
+	golang.org/x/mod v0.24.0
 	golang.org/x/oauth2 v0.7.0
 	golang.org/x/tools v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
 golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/mod_test.go
+++ b/mod_test.go
@@ -1,9 +1,9 @@
 package mod
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -38,7 +38,7 @@ func TestGetModFileErrors(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if !strings.Contains(err.Error(), "could not open go.mod") {
+		if !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -50,12 +50,8 @@ func TestGetModFileErrors(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = GetModFile(dir)
-		if err == nil {
+		if _, err := GetModFile(dir); err == nil {
 			t.Fatal("expected error")
-		}
-		if !strings.Contains(err.Error(), "could not parse go.mod") {
-			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }

--- a/mod_test.go
+++ b/mod_test.go
@@ -1,0 +1,61 @@
+package mod
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetModFile(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(`
+module example.com/foo
+
+require example.com/whatever v1.2.3
+
+tool example.com/whatever/cmd/thing
+
+go 1.23.4
+`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mod, err := GetModFile(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if mod.Module.Mod.Path != "example.com/foo" {
+		t.Fatalf("unexpected module path: %v", mod.Module.Mod.Path)
+	}
+}
+
+func TestGetModFileErrors(t *testing.T) {
+	t.Run("DoesNotExist", func(t *testing.T) {
+		_, err := GetModFile(t.TempDir())
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "could not open go.mod") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("SyntaxError", func(t *testing.T) {
+		dir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("syntax error"), 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = GetModFile(dir)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "could not parse go.mod") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Go 1.24 introduced 'tool' directives in go.mod files.
mod currently breaks on any go.mod file with a 'tool' directive:

```
go.mod:140: unknown directive: tool
could not parse go.mod file
github.com/marwan-at-work/mod.GetModFile
	[..]/github.com/marwan-at-work/mod@v0.7.1/mod.go:20
```

The fix is straightforward: update to latest golang.org/x/mod.
