### PR TITLE
do not try to update non go files

### DIFF
--- a/major/major.go
+++ b/major/major.go
@@ -162,6 +162,11 @@ func updateImportPath(p *packages.Package, old, new, sep string, files map[strin
 
 	goFileNames := append(p.GoFiles, p.IgnoredFiles...)
 	for _, goFileName := range goFileNames {
+		// The file list can include other files such as C files that cannot be parsed,
+		// skip anything that isn't a .go file.
+		if !strings.HasSuffix(goFileName, ".go") {
+			continue
+		}
 
 		if _, ok := files[goFileName]; ok {
 			continue


### PR DESCRIPTION
Only valid go files can be parsed, if you have a project with c files next to the go code the update will fail as it tries to parse all files not just the go ones.

Trying to parse a c file fail with "illegal character U+0023 '#'" for example and thus fails the upgrade command.